### PR TITLE
Support custom formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ This parameter specifies the number of decimal points to display. Defaults to 0.
 rounding: 2
 ```
 
+#### format (function)
+
+A function to be called for custom formatting of the value. If set, `rounding` and `delimiter` will be ignored.
+
+```js
+format: function (val) {
+    return val + ' $';
+}
+```
+
 #### toValue (number)
 
 The final value that you want the number to be animated to.

--- a/jquery-numerator.js
+++ b/jquery-numerator.js
@@ -34,6 +34,7 @@
         duration: 500,
         delimiter: undefined,
         rounding: 0,
+        format: undefined,
         toValue: undefined,
         fromValue: undefined,
         queue: false,
@@ -90,6 +91,10 @@
 
         format: function(value){
             var self = this;
+
+            if ($.isFunction(this.settings.format)) {
+                return this.settings.format(value);
+            }
 
             if ( parseInt(this.settings.rounding ) < 1) {
                 value = parseInt(value, 10);


### PR DESCRIPTION
- Extend the functionality by adding a `format` property which will be called instead of using `rounding`/`delimiter`.
- No breaking changes.

Example use cases:
- format the value to be a currency
- localized thousand/decimal separator